### PR TITLE
Add LED and battery symbols

### DIFF
--- a/memories.js
+++ b/memories.js
@@ -341,7 +341,7 @@ function placeSymbolCurve(curve){
         var norm = curve.getNormalAt(curveLocation);
     
     
-        var choose = rnd(0,10);
+        var choose = rnd(0,11);
         switch(choose){
             case 0:
                 lamp(curve, curveLocation, place, norm);
@@ -375,6 +375,9 @@ function placeSymbolCurve(curve){
                 break;
             case 10:
                 battery(curve, curveLocation, place, norm);
+                break;
+            case 11:
+                led(curve, curveLocation, place, norm);
                 break;
         }
     }else{
@@ -641,6 +644,83 @@ function battery(curve, curveLocation, place, norm) {
     addStyle(shortLine);
 
     drawWire(7 * fak, curve, curveLocation);
+}
+
+/**
+ * Draw an LED
+ */
+function led(curve, curveLocation, place, norm) {
+    var triangle = new Path();
+    var line = new Path();
+    var arrow1;
+    var arrow2;
+
+    if (norm.x == 1 || norm.x == -1) {
+        // Place on vertical line
+        triangle.add(place.subtract(new Point(-10, 0).multiply(fak)));
+        triangle.add(place.subtract(new Point(10, 0).multiply(fak)));
+        triangle.add(place.subtract(new Point(0, 20).multiply(norm.x * fak)));
+
+        line.add(place.subtract(new Point(-10, 20).multiply(norm.x * fak)));
+        line.add(place.subtract(new Point(10, 20).multiply(norm.x * fak)));
+
+        arrow1 = arrowTo(place.subtract((new Point(25, 25).multiply(norm.x * fak))), norm);
+        arrow2 = arrowTo(place.subtract((new Point(28, 13).multiply(norm.x * fak))), norm);
+
+        drawWire(10 * fak, curve, curveLocation - 10 * fak);
+    } else {
+        // Place on horizontal line
+        triangle.add(place.subtract(new Point(0, -10).multiply(fak)));
+        triangle.add(place.subtract(new Point(0, 10).multiply(fak)));
+        triangle.add(place.subtract(new Point(20, 0).multiply(norm.y * fak)));
+
+        line.add(place.subtract(new Point(20, -10).multiply(norm.y * fak)));
+        line.add(place.subtract(new Point(20, 10).multiply(norm.y * fak)));
+
+        arrow1 = arrowTo(place.subtract((new Point(25, -25).multiply(norm.y * fak))), norm);
+        arrow2 = arrowTo(place.subtract((new Point(13, -28).multiply(norm.y * fak))), norm);
+
+        drawWire(10 * fak, curve, curveLocation + 10 * fak);
+    }
+    triangle.closed = true;
+    addStyle(line);
+    addStyle(triangle);
+
+    for (var i in arrow1) {
+        addStyle(arrow1[i])
+    }
+    for (var i in arrow2) {
+        addStyle(arrow2[i])
+    }
+}
+
+/**
+ * Creates a small arrow for the LED
+ *
+ * @param target Target of arrow
+ * @returns {Path[]}
+ */
+function arrowTo(target, norm) {
+    var line = new Path();
+    var tip = new Path();
+
+    if (norm.x == 1 || norm.x == -1) {
+        line.add(target.subtract((new Point(-7, -7).multiply(norm.x * fak))));
+        line.add(target);
+
+        tip.add(target.subtract((new Point(0, -5).multiply(norm.x * fak))));
+        tip.add(target);
+        tip.add(target.subtract((new Point(-5, 0).multiply(norm.x * fak))));
+    } else {
+        line.add(target.subtract((new Point(-7, 7).multiply(norm.y * fak))));
+        line.add(target);
+
+        tip.add(target.subtract((new Point(-5, 0).multiply(norm.y * fak))));
+        tip.add(target);
+        tip.add(target.subtract((new Point(0, 5).multiply(norm.y * fak))));
+    }
+
+    return [line, tip];
 }
 
 function drawWire(size, curve, curveLocation){


### PR DESCRIPTION
This adds battery and LED symbols.

Known issue: Arrows of adjacent LEDs could overlap, ideas on how to fix this would be appreciated.